### PR TITLE
Fix proxyprefix.contrib package name in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.1.1
 
-* Add `contrib.djproxy.XForwardedPrefix` for sending X-Forwarded-Prefix
-  header in local dev.
+* Add `proxyprefix.contrib.djproxy.XForwardedPrefix` for sending
+  X-Forwarded-Prefix header in local dev.
 
 ## 0.1.0
 


### PR DESCRIPTION
See conversation that begins here:
https://github.com/yola/proxyprefix/pull/5#issuecomment-76929076