### PR TITLE
Explicitly set url scheme when passing X-Forwarded-Proto

### DIFF
--- a/proxyprefix/wsgi.py
+++ b/proxyprefix/wsgi.py
@@ -6,8 +6,14 @@ class ReverseProxiedApp(object):
 
     def __call__(self, environ, start_response):
         prefix = environ.get('HTTP_X_FORWARDED_PREFIX')
+        scheme = environ.get('HTTP_X_FORWARDED_PROTO')
+
         if prefix:
             prefix_paths(environ, prefix)
+
+        if scheme:
+            environ['wsgi.url_scheme'] = scheme
+
         return self.app(environ, start_response)
 
 

--- a/proxyprefix/wsgi.py
+++ b/proxyprefix/wsgi.py
@@ -12,8 +12,7 @@ class ReverseProxiedApp(object):
             prefix_paths(environ, prefix)
 
         if scheme:
-            scheme = 'https' if scheme == 'https' else 'http'
-            environ['wsgi.url_scheme'] = scheme
+            set_scheme(environ, scheme)
 
         return self.app(environ, start_response)
 
@@ -32,3 +31,9 @@ def prefix_paths(environ, prefix):
     # this django quirk:
     if environ.get('SCRIPT_URL'):
         environ['SCRIPT_URL'] = ''
+
+
+def set_scheme(environ, scheme):
+    """Force environ to be http or https."""
+    scheme = 'https' if scheme == 'https' else 'http'
+    environ['wsgi.url_scheme'] = scheme

--- a/proxyprefix/wsgi.py
+++ b/proxyprefix/wsgi.py
@@ -37,3 +37,4 @@ def set_scheme(environ, scheme):
     """Force environ to be http or https."""
     scheme = 'https' if scheme == 'https' else 'http'
     environ['wsgi.url_scheme'] = scheme
+    environ['HTTPS'] = 'on' if scheme == 'https' else 'off'

--- a/proxyprefix/wsgi.py
+++ b/proxyprefix/wsgi.py
@@ -12,6 +12,7 @@ class ReverseProxiedApp(object):
             prefix_paths(environ, prefix)
 
         if scheme:
+            scheme = 'https' if scheme == 'https' else 'http'
             environ['wsgi.url_scheme'] = scheme
 
         return self.app(environ, start_response)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware',
     ],
-    extras_require = {
+    extras_require={
         'djproxy': ['djproxy>=2.0.0'],
     },
 )

--- a/tests/test_reverse_proxied_app.py
+++ b/tests/test_reverse_proxied_app.py
@@ -30,6 +30,15 @@ class TestReverseProxiedApp(TestCase):
         self.proxied_app(self.environ, self.start_response)
         self.prefix_paths.assert_called_with(self.environ, 'prefix')
 
+    def test_it_does_not_set_scheme_if_no_HTTP_X_FORWARDED_PROTO(self):
+        self.proxied_app(self.environ, self.start_response)
+        self.assertIsNone(self.environ.get('wsgi.url_scheme'))
+
+    def test_it_sets_scheme_to_HTTP_X_FORWARDED_PROTO(self):
+        self.environ['HTTP_X_FORWARDED_PROTO'] = 'http'
+        self.proxied_app(self.environ, self.start_response)
+        self.assertEqual(self.environ.get('wsgi.url_scheme'), 'http')
+
 
 class TestPrefixPaths(TestCase):
     """prefix_paths(environ, prefix)"""

--- a/tests/test_reverse_proxied_app.py
+++ b/tests/test_reverse_proxied_app.py
@@ -79,3 +79,11 @@ class TestSetScheme(TestCase):
     def test_sets_wsgi_url_scheme_to_http_if_scheme_is_not_https(self):
         set_scheme(self.environ, 'foo')
         self.assertEqual(self.environ['wsgi.url_scheme'], 'http')
+
+    def test_sets_HTTPS_to_on_if_scheme_is_https(self):
+        set_scheme(self.environ, 'https')
+        self.assertEqual(self.environ['HTTPS'], 'on')
+
+    def test_sets_HTTPS_to_off_if_scheme_is_not_https(self):
+        set_scheme(self.environ, 'foo')
+        self.assertEqual(self.environ['HTTPS'], 'off')

--- a/tests/test_reverse_proxied_app.py
+++ b/tests/test_reverse_proxied_app.py
@@ -6,9 +6,9 @@ from proxyprefix.wsgi import prefix_paths, ReverseProxiedApp
 
 class TestReverseProxiedApp(TestCase):
     def setUp(self):
-        self.prefix_paths_patcher = patch('proxyprefix.wsgi.prefix_paths')
-        self.prefix_paths = self.prefix_paths_patcher.start()
-        self.addCleanup(self.prefix_paths_patcher.stop)
+        prefix_paths_patcher = patch('proxyprefix.wsgi.prefix_paths')
+        self.prefix_paths = prefix_paths_patcher.start()
+        self.addCleanup(prefix_paths_patcher.stop)
 
         self.environ = {}
         self.start_response = Mock()


### PR DESCRIPTION
This will let non-secure proxies tell a secure service to construct http URLs instead of https.